### PR TITLE
TOLK-2451: Automatisk tildeling av tillatelsessett for brukere til lesehjelp community

### DIFF
--- a/force-app/main/default/classes/CommunityUsersService.cls
+++ b/force-app/main/default/classes/CommunityUsersService.cls
@@ -194,7 +194,14 @@ public with sharing class CommunityUsersService {
             PermissionSetAssignment assignment = new PermissionSetAssignment();
             assignment.AssigneeId = userId;
             assignment.PermissionSetId = defaultPermissionSets[0].PermissionSetId__c;
-            insert assignment;
+            
+            try {
+                insert assignment;
+            } catch (Exception e) {
+                LoggerUtility logger = new LoggerUtility();
+                logger.exception(e, CRM_ApplicationDomain.Domain.CRM);
+                logger.publishSynch();
+            }
         }
     }
 

--- a/force-app/main/default/classes/PersonAccountUserRegHandler.cls
+++ b/force-app/main/default/classes/PersonAccountUserRegHandler.cls
@@ -1,11 +1,12 @@
 global class PersonAccountUserRegHandler implements Auth.RegistrationHandler {
-    private List<String> samhandlerNetworkIds=new List<String>{'0DB7U000000TN3u','0DB5t00000001tH'};
+    private List<String> samhandlerNetworkIds=new List<String>{'0DB7U000000TN3u','0DB5t00000001tH'}; // The id's for Arbeidsgiver Dialog Community in PROD and SIT2
+    
     global User createUser(Id portalId, Auth.UserData data) {
         String personIdent = data.attributeMap.get('pid');
         String communityId = data.attributeMap.get('sfdc_networkid');
 
         DefaultCommunityProfile__c defaultCommunityProfiles = DefaultCommunityProfile__c.getOrgDefaults();
-        String defaultCommunityPlusLoginCommunityId = defaultCommunityProfiles.DefaultCommunityPlusLoginCommunityId__c;
+        String defaultCommunityPlusLoginCommunityId = defaultCommunityProfiles.DefaultCommunityPlusLoginCommunityId__c; // The id for Aa-registeret Community
         if (
             communityId != null &&
             defaultCommunityPlusLoginCommunityId != null &&
@@ -20,9 +21,7 @@ global class PersonAccountUserRegHandler implements Auth.RegistrationHandler {
             return user;
         }
         User user = CommunityUsersService.getOrCreatePersonAccountUser(personIdent);
-        if (communityId == '0DB2o000000Ug9I' || communityId == '0DB1l0000008QNv' || communityId == '0DB2o000000Ug9D') {
-            CommunityUsersService.assignCommunitySpecificPermissionSet(user.Id, communityId);
-        }
+        CommunityUsersService.assignCommunitySpecificPermissionSet(user.Id, communityId);
 
         return user;
     }
@@ -31,7 +30,7 @@ global class PersonAccountUserRegHandler implements Auth.RegistrationHandler {
         String personIdent = data.attributeMap.get('pid');
         String communityId = data.attributeMap.get('sfdc_networkid');
         DefaultCommunityProfile__c defaultCommunityProfiles = DefaultCommunityProfile__c.getOrgDefaults();
-        String defaultCommunityPlusLoginCommunityId = defaultCommunityProfiles.DefaultCommunityPlusLoginCommunityId__c;
+        String defaultCommunityPlusLoginCommunityId = defaultCommunityProfiles.DefaultCommunityPlusLoginCommunityId__c; // The id for Aa-registeret Community
         if (
             communityId != null &&
             defaultCommunityPlusLoginCommunityId != null &&
@@ -45,8 +44,6 @@ global class PersonAccountUserRegHandler implements Auth.RegistrationHandler {
             }
         }
 
-        if (communityId == '0DB2o000000Ug9I' || communityId == '0DB1l0000008QNv' || communityId == '0DB2o000000Ug9D') {
-            CommunityUsersService.assignCommunitySpecificPermissionSet(userId, communityId);
-        }
+        CommunityUsersService.assignCommunitySpecificPermissionSet(userId, communityId);
     }
 }

--- a/force-app/main/default/classes/PersonAccountUserRegHandlerTest.cls
+++ b/force-app/main/default/classes/PersonAccountUserRegHandlerTest.cls
@@ -5,14 +5,18 @@ private class PersonAccountUserRegHandlerTest {
         Profile communityProfile = [
             SELECT Name
             FROM Profile
-            WHERE Name = 'Personbruker Login' OR Name = 'Trial Customer Portal User'
+            WHERE
+                Name = 'Personbruker Login'
+                OR Name = 'Trial Customer Portal User'
             LIMIT 1
         ];
 
         Profile communityPlusLoginProfile = [
             SELECT Name
             FROM Profile
-            WHERE Name = 'Samhandler Login' OR Name = 'Trial Customer Portal User'
+            WHERE
+                Name = 'Samhandler Login'
+                OR Name = 'Trial Customer Portal User'
             LIMIT 1
         ];
 
@@ -30,9 +34,16 @@ private class PersonAccountUserRegHandlerTest {
 
     @IsTest
     private static void createUser() {
-        User navEmployee = TestDataFactory_Community.getUsers(1, 'System Administrator', true, true)[0];
+        User navEmployee = TestDataFactory_Community.getUsers(
+            1,
+            'System Administrator',
+            true,
+            true
+        )[0];
         System.runAs(navEmployee) {
-            Account personAccount = TestDataFactory_Community.getPersonAccounts(1)[0];
+            Account personAccount = TestDataFactory_Community.getPersonAccounts(
+                1
+            )[0];
             TestDataFactory_Community.getEmployerCommunityUser(
                 new Set<Id>{ personAccount.Id },
                 'Personbruker Login',
@@ -41,7 +52,19 @@ private class PersonAccountUserRegHandlerTest {
 
             Map<String, String> attributeMap = new Map<String, String>();
             attributeMap.put('pid', '1');
-            Auth.UserData userData = new Auth.UserData('', '', '', '', '', '', '', '', '', '', attributeMap);
+            Auth.UserData userData = new Auth.UserData(
+                '',
+                '',
+                '',
+                '',
+                '',
+                '',
+                '',
+                '',
+                '',
+                '',
+                attributeMap
+            );
 
             Test.startTest();
             PersonAccountUserRegHandler regHandler = new PersonAccountUserRegHandler();
@@ -49,13 +72,20 @@ private class PersonAccountUserRegHandlerTest {
             Test.stopTest();
             System.assert(user != null);
 
-            PermissionSet permSet = [SELECT Id FROM PermissionSet WHERE Name = 'TestCommunity' LIMIT 1];
+            PermissionSet permSet = [
+                SELECT Id
+                FROM PermissionSet
+                WHERE Name = 'TestCommunity'
+                LIMIT 1
+            ];
             System.assertEquals(
                 0,
                 [
                     SELECT COUNT()
                     FROM PermissionSetAssignment
-                    WHERE PermissionSetId = :permSet.Id AND AssigneeId = :user.Id
+                    WHERE
+                        PermissionSetId = :permSet.Id
+                        AND AssigneeId = :user.Id
                 ],
                 'Expect perm set not to be assigned to community user'
             );
@@ -64,17 +94,40 @@ private class PersonAccountUserRegHandlerTest {
 
     @IsTest
     private static void createConfidentialUser() {
-        User navEmployee = TestDataFactory_Community.getUsers(1, 'System Administrator', true, true)[0];
+        User navEmployee = TestDataFactory_Community.getUsers(
+            1,
+            'System Administrator',
+            true,
+            true
+        )[0];
         System.runAs(navEmployee) {
-            Account personAccount = TestDataFactory_Community.getPersonAccounts(1)[0];
+            Account personAccount = TestDataFactory_Community.getPersonAccounts(
+                1
+            )[0];
 
-            Person__c person = [SELECT INT_Confidential__c FROM Person__c WHERE Id = :personAccount.CRM_Person__c];
+            Person__c person = [
+                SELECT INT_Confidential__c
+                FROM Person__c
+                WHERE Id = :personAccount.CRM_Person__c
+            ];
             person.INT_Confidential__c = 'FORTROLIG';
             update person;
 
             Map<String, String> attributeMap = new Map<String, String>();
             attributeMap.put('pid', '1');
-            Auth.UserData userData = new Auth.UserData('', '', '', '', '', '', '', '', '', '', attributeMap);
+            Auth.UserData userData = new Auth.UserData(
+                '',
+                '',
+                '',
+                '',
+                '',
+                '',
+                '',
+                '',
+                '',
+                '',
+                attributeMap
+            );
 
             Test.startTest();
             PersonAccountUserRegHandler regHandler = new PersonAccountUserRegHandler();
@@ -84,13 +137,20 @@ private class PersonAccountUserRegHandlerTest {
             System.assert(user != null);
             System.assert(user.isActive == true);
 
-            PermissionSet permSet = [SELECT Id FROM PermissionSet WHERE Name = 'TestCommunity' LIMIT 1];
+            PermissionSet permSet = [
+                SELECT Id
+                FROM PermissionSet
+                WHERE Name = 'TestCommunity'
+                LIMIT 1
+            ];
             System.assertEquals(
                 0,
                 [
                     SELECT COUNT()
                     FROM PermissionSetAssignment
-                    WHERE PermissionSetId = :permSet.Id AND AssigneeId = :user.Id
+                    WHERE
+                        PermissionSetId = :permSet.Id
+                        AND AssigneeId = :user.Id
                 ],
                 'Expect perm set not to be assigned to community user'
             );
@@ -101,7 +161,19 @@ private class PersonAccountUserRegHandlerTest {
     private static void updateUser() {
         Map<String, String> attributeMap = new Map<String, String>();
         attributeMap.put('pid', '1');
-        Auth.UserData userData = new Auth.UserData('', '', '', '', '', '', '', '', '', '', attributeMap);
+        Auth.UserData userData = new Auth.UserData(
+            '',
+            '',
+            '',
+            '',
+            '',
+            '',
+            '',
+            '',
+            '',
+            '',
+            attributeMap
+        );
 
         Test.startTest();
         PersonAccountUserRegHandler regHandler = new PersonAccountUserRegHandler();
@@ -111,9 +183,16 @@ private class PersonAccountUserRegHandlerTest {
 
     @IsTest
     private static void createCommunityPlusLoginUser() {
-        User navEmployee = TestDataFactory_Community.getUsers(1, 'System Administrator', true, true)[0];
+        User navEmployee = TestDataFactory_Community.getUsers(
+            1,
+            'System Administrator',
+            true,
+            true
+        )[0];
         System.runAs(navEmployee) {
-            Account personAccount = TestDataFactory_Community.getPersonAccounts(1)[0];
+            Account personAccount = TestDataFactory_Community.getPersonAccounts(
+                1
+            )[0];
             TestDataFactory_Community.getEmployerCommunityUser(
                 new Set<Id>{ personAccount.Id },
                 'Personbruker Login',
@@ -123,7 +202,19 @@ private class PersonAccountUserRegHandlerTest {
             Map<String, String> attributeMap = new Map<String, String>();
             attributeMap.put('pid', '1');
             attributeMap.put('sfdc_networkid', '123');
-            Auth.UserData userData = new Auth.UserData('', '', '', '', '', '', '', '', '', '', attributeMap);
+            Auth.UserData userData = new Auth.UserData(
+                '',
+                '',
+                '',
+                '',
+                '',
+                '',
+                '',
+                '',
+                '',
+                '',
+                attributeMap
+            );
 
             Test.startTest();
             PersonAccountUserRegHandler regHandler = new PersonAccountUserRegHandler();
@@ -131,13 +222,20 @@ private class PersonAccountUserRegHandlerTest {
             Test.stopTest();
             System.assert(user != null);
 
-            PermissionSet permSet = [SELECT Id FROM PermissionSet WHERE Name = 'TestCommunity' LIMIT 1];
+            PermissionSet permSet = [
+                SELECT Id
+                FROM PermissionSet
+                WHERE Name = 'TestCommunity'
+                LIMIT 1
+            ];
             System.assertEquals(
                 1,
                 [
                     SELECT COUNT()
                     FROM PermissionSetAssignment
-                    WHERE PermissionSetId = :permSet.Id AND AssigneeId = :user.Id
+                    WHERE
+                        PermissionSetId = :permSet.Id
+                        AND AssigneeId = :user.Id
                 ],
                 'Expect perm set to be assigned to new user'
             );

--- a/force-app/main/default/classes/PersonAccountUserRegHandlerTest.cls
+++ b/force-app/main/default/classes/PersonAccountUserRegHandlerTest.cls
@@ -79,7 +79,7 @@ private class PersonAccountUserRegHandlerTest {
                 LIMIT 1
             ];
             System.assertEquals(
-                0,
+                1,
                 [
                     SELECT COUNT()
                     FROM PermissionSetAssignment
@@ -87,7 +87,7 @@ private class PersonAccountUserRegHandlerTest {
                         PermissionSetId = :permSet.Id
                         AND AssigneeId = :user.Id
                 ],
-                'Expect perm set not to be assigned to community user'
+                'Expect perm set to be assigned to new user'
             );
         }
     }
@@ -144,7 +144,7 @@ private class PersonAccountUserRegHandlerTest {
                 LIMIT 1
             ];
             System.assertEquals(
-                0,
+                1,
                 [
                     SELECT COUNT()
                     FROM PermissionSetAssignment
@@ -152,33 +152,52 @@ private class PersonAccountUserRegHandlerTest {
                         PermissionSetId = :permSet.Id
                         AND AssigneeId = :user.Id
                 ],
-                'Expect perm set not to be assigned to community user'
+                'Expect perm set to be assigned to new user'
             );
         }
     }
 
     @IsTest
     private static void updateUser() {
-        Map<String, String> attributeMap = new Map<String, String>();
-        attributeMap.put('pid', '1');
-        Auth.UserData userData = new Auth.UserData(
-            '',
-            '',
-            '',
-            '',
-            '',
-            '',
-            '',
-            '',
-            '',
-            '',
-            attributeMap
-        );
+        User navEmployee = TestDataFactory_Community.getUsers(
+            1,
+            'System Administrator',
+            true,
+            true
+        )[0];
+        System.runAs(navEmployee) {
+            Account personAccount = TestDataFactory_Community.getPersonAccounts(
+                1
+            )[0];
+            TestDataFactory_Community.getEmployerCommunityUser(
+                new Set<Id>{ personAccount.Id },
+                'Personbruker Login',
+                true
+            );
 
-        Test.startTest();
-        PersonAccountUserRegHandler regHandler = new PersonAccountUserRegHandler();
-        regHandler.updateUser(null, null, userData);
-        Test.stopTest();
+            Map<String, String> attributeMap = new Map<String, String>();
+            attributeMap.put('pid', '1');
+            Auth.UserData userData = new Auth.UserData(
+                '',
+                '',
+                '',
+                '',
+                '',
+                '',
+                '',
+                '',
+                '',
+                '',
+                attributeMap
+            );
+
+            PersonAccountUserRegHandler regHandler = new PersonAccountUserRegHandler();
+            User user = regHandler.createUser(null, userData);
+
+            Test.startTest();
+            regHandler.updateUser(null, null, userData);
+            Test.stopTest();
+        }
     }
 
     @IsTest

--- a/force-app/main/default/customMetadata/DefaultCommunityPermissionSet.Lesehjelp_PROD.md-meta.xml
+++ b/force-app/main/default/customMetadata/DefaultCommunityPermissionSet.Lesehjelp_PROD.md-meta.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <label>Lesehjelp - PROD</label>
+    <protected>false</protected>
+    <values>
+        <field>NetworkId__c</field>
+        <value xsi:type="xsd:string">0DB7U0000004C9rWAE</value>
+    </values>
+    <values>
+        <field>PermissionSetId__c</field>
+        <value xsi:type="xsd:string">0PS7U000000Xjr1WAC</value>
+    </values>
+</CustomMetadata>

--- a/scripts/newScratchOrg.bat
+++ b/scripts/newScratchOrg.bat
@@ -1,11 +1,13 @@
-:: Opprett en scratch org
-call sfdx force:org:create -f config\project-scratch-def.json --setalias %1 --durationdays %2 --setdefaultusername --json --loglevel fatal  --wait 10
+echo "Oppretter scratch org"
+call sf org create scratch --definition-file config\project-scratch-def.json --alias %1 --duration-days %2 --set-default --json --wait 30
 
-:: Installer crm-platform-base v0.169
-call sfdx force:package:install --package 04t7U000000TqIuQAK -r -k %3 --wait 10 --publishwait 10
+echo "Installer crm-platform-base v0.169"
+call sf package install --package 04t7U000000TqIuQAK --no-prompt --installation-key %3 --wait 30 --publish-wait 30
 
-:: Installer crm-platform-access-control v0.101
-call sfdx force:package:install --package 04t7U000000TpqbQAC -r -k %3 --wait 10 --publishwait 10
+echo "Installer crm-platform-access-control v0.101"
+call sf package install --package 04t7U000000TpqbQAC --no-prompt --installation-key %3 --wait 30 --publish-wait 30
 
-:: Dytt kildekoden til scratch org'en
-call sfdx force:source:push
+echo "Dytter kildekoden til scratch org'en"
+call sf project deploy start
+
+echo "Ferdig"


### PR DESCRIPTION
**Endringlogg**

- Har lagt til Default Community Permission Set for Lesehjelp Community
- Har lagt til feilhåndtering og logging på tildeling av perm. set. i CommunityUsersService
- Fjernet filter for når assignCommunitySpecificPermissionSet() skal gjøres, så den nå kjøres for alle Communites (men gjør ikke noe hvis man ikke også har lagt inn en Default Community Permission Set)
- La til litt kommentarer rundt Network Id så det er lettere å se hva som skjer for hvilket Community

**Gjenstår**

- [X] Fikse tester 