### PR TITLE
Secondary knapp mistet border når man byttet til ny dekoratør

### DIFF
--- a/force-app/main/default/lwc/button/button.css
+++ b/force-app/main/default/lwc/button/button.css
@@ -15,6 +15,9 @@
     padding: calc(0.75rem - 2px) 0.75rem;
 }
 
+.navds-button--secondary {
+    border: 2px solid #0067c5;
+}
 .navds-button--secondary:hover,
 .navds-button--secondary:active {
     color: #ffffff;


### PR DESCRIPTION
Sånn det så ut med gammel dekoratør:
<img width="1012" alt="Skjermbilde 2024-07-12 kl  11 33 40" src="https://github.com/user-attachments/assets/13553a82-7a8d-40dd-8dd0-e08fcae1669c">

Sånn det ble med ny dekoratør:  (uten denne nye koden)
<img width="987" alt="gammel dek" src="https://github.com/user-attachments/assets/0579bc0a-5ba6-4e1d-9e0f-13c5417c4929">
