### PR TITLE
Refactor token refresh controller logging

### DIFF
--- a/force-app/IdPorten/classes/IdPortenException.cls
+++ b/force-app/IdPorten/classes/IdPortenException.cls
@@ -1,0 +1,11 @@
+/**
+ * @description Custom exception for IdPorten errors.
+ *
+ * @author Tor Håkon Sigurdsen
+ * @since 2025-jun
+ */
+public without sharing class IdPortenException extends Exception {
+    // Added in order to avoid no test coverage even if the exception class is used.
+    // This is probably a bug in the Salesforce platform.
+    private Boolean IdPortenException = true;
+}

--- a/force-app/IdPorten/classes/IdPortenException.cls-meta.xml
+++ b/force-app/IdPorten/classes/IdPortenException.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>64.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/IdPorten/classes/IdPortenTokenRefreshController.cls
+++ b/force-app/IdPorten/classes/IdPortenTokenRefreshController.cls
@@ -1,6 +1,6 @@
 public with sharing class IdPortenTokenRefreshController {
     private static final Integer SESSION_DURATION_IN_MINUTES = 24;
-    LoggerUtility logger;
+    private final LoggerUtility logger;
 
     public IdPortenTokenRefreshController() {
         logger = new LoggerUtility(
@@ -14,7 +14,7 @@ public with sharing class IdPortenTokenRefreshController {
     }
 
     public PageReference validateAndRedirect() {
-        if (this.isScratchOrg(URL.getOrgDomainUrl().toExternalForm()) == true) {
+        if (this.isScratchOrg(URL.getOrgDomainUrl().toExternalForm())) {
             String redirectUrl = ApexPages.currentPage()
                 .getParameters()
                 .get('redirectUrl');

--- a/force-app/IdPorten/classes/IdPortenTokenRefreshController.cls
+++ b/force-app/IdPorten/classes/IdPortenTokenRefreshController.cls
@@ -3,13 +3,23 @@ public with sharing class IdPortenTokenRefreshController {
 
     public PageReference validateAndRedirect() {
         // Code from https://salesforce.stackexchange.com/questions/256499/how-can-i-determine-if-the-org-that-im-currently-connected-to-is-a-scratch-org
-        Organization org = [SELECT IsSandbox, TrialExpirationDate FROM Organization];
-        Boolean isScratchOrg = org?.IsSandbox && org?.TrialExpirationDate != null;
-        
+        Organization org = [
+            SELECT IsSandbox, TrialExpirationDate
+            FROM Organization
+        ];
+        Boolean isScratchOrg =
+            org?.IsSandbox && org?.TrialExpirationDate != null;
+
         if (isScratchOrg == true) {
-            String redirectUrl = ApexPages.currentPage().getParameters().get('redirectUrl');
+            String redirectUrl = ApexPages.currentPage()
+                .getParameters()
+                .get('redirectUrl');
             ApexPages.currentPage()
-                .setCookies(new List<Cookie>{ new Cookie('redirectUrl', redirectUrl, null, 900, true)});
+                .setCookies(
+                    new List<Cookie>{
+                        new Cookie('redirectUrl', redirectUrl, null, 900, true)
+                    }
+                );
             pageReference pgTester = new pageReference(redirectUrl);
             return pgTester.setRedirect(true);
         }
@@ -23,10 +33,14 @@ public with sharing class IdPortenTokenRefreshController {
         Cookie retUrlCookie;
         Cookie redirectUrlCookie;
         String code = apexpages.currentPage().getParameters().get('code');
-        String redirectUrl = ApexPages.currentPage().getParameters().get('redirectUrl');
+        String redirectUrl = ApexPages.currentPage()
+            .getParameters()
+            .get('redirectUrl');
 
         //don't refresh if mobile app
-        String userAgent = ApexPages.currentPage().getHeaders().get('USER-AGENT');
+        String userAgent = ApexPages.currentPage()
+            .getHeaders()
+            .get('USER-AGENT');
         if (userAgent != null && userAgent.contains('SalesforceMobileSDK')) {
             pageReference pg = new pageReference(redirectUrl);
             return pg.setRedirect(true);
@@ -34,16 +48,49 @@ public with sharing class IdPortenTokenRefreshController {
 
         //initiate
         if (code == null) {
-            redirectUrlCookie = new Cookie('redirectUrl', redirectUrl, null, 900, true);
+            redirectUrlCookie = new Cookie(
+                'redirectUrl',
+                redirectUrl,
+                null,
+                900,
+                true
+            );
 
             IdPortenAuthUtil authUtil = new IdPortenAuthUtil();
-            IdPortenAuthUtil.AuthResponse authResponse = authUtil.initiate('IdPortenTokenRefresh');
-            codeVerifierCookie = new Cookie('codeverifier', authResponse.codeVerifier, null, 1800, true);
-            stateCookie = new Cookie('state', authResponse.state, null, 1800, true);
-            nonceCookie = new Cookie('nonce', authResponse.nonce, null, 1800, true);
+            IdPortenAuthUtil.AuthResponse authResponse = authUtil.initiate(
+                'IdPortenTokenRefresh'
+            );
+            codeVerifierCookie = new Cookie(
+                'codeverifier',
+                authResponse.codeVerifier,
+                null,
+                1800,
+                true
+            );
+            stateCookie = new Cookie(
+                'state',
+                authResponse.state,
+                null,
+                1800,
+                true
+            );
+            nonceCookie = new Cookie(
+                'nonce',
+                authResponse.nonce,
+                null,
+                1800,
+                true
+            );
 
             ApexPages.currentPage()
-                .setCookies(new List<Cookie>{ codeVerifierCookie, stateCookie, nonceCookie, redirectUrlCookie });
+                .setCookies(
+                    new List<Cookie>{
+                        codeVerifierCookie,
+                        stateCookie,
+                        nonceCookie,
+                        redirectUrlCookie
+                    }
+                );
             pageReference pg = new pageReference(authResponse.initiateUrl);
             return pg.setRedirect(true);
         }
@@ -52,16 +99,28 @@ public with sharing class IdPortenTokenRefreshController {
         try {
             String state = apexpages.currentPage().getParameters().get('state');
 
-            codeVerifierCookie = ApexPages.currentPage().getCookies().get('codeVerifier');
+            codeVerifierCookie = ApexPages.currentPage()
+                .getCookies()
+                .get('codeVerifier');
             stateCookie = ApexPages.currentPage().getCookies().get('state');
             nonceCookie = ApexPages.currentPage().getCookies().get('nonce');
-            redirectUrlCookie = ApexPages.currentPage().getCookies().get('redirectUrl');
+            redirectUrlCookie = ApexPages.currentPage()
+                .getCookies()
+                .get('redirectUrl');
             String redirectUrlFromCookie = redirectUrlCookie.getValue();
             pageReference pg = new pageReference(redirectUrlFromCookie);
 
-            if (codeVerifierCookie == null || stateCookie == null || nonceCookie == null) {
+            if (
+                codeVerifierCookie == null ||
+                stateCookie == null ||
+                nonceCookie == null
+            ) {
                 LoggerUtility logger = new LoggerUtility();
-                logger.error('Cookies er ikke satt', null, CRM_ApplicationDomain.Domain.NKS);
+                logger.error(
+                    'Cookies er ikke satt',
+                    null,
+                    CRM_ApplicationDomain.Domain.NKS
+                );
                 logger.publishSynch();
                 return pg.setRedirect(true);
             }
@@ -72,7 +131,11 @@ public with sharing class IdPortenTokenRefreshController {
 
             if (state == null || state != stateFromCookie) {
                 LoggerUtility logger = new LoggerUtility();
-                logger.error('State samsvarer ikke', null, CRM_ApplicationDomain.Domain.NKS);
+                logger.error(
+                    'State samsvarer ikke',
+                    null,
+                    CRM_ApplicationDomain.Domain.NKS
+                );
                 logger.publishSynch();
                 return pg.setRedirect(true);
             }
@@ -89,9 +152,31 @@ public with sharing class IdPortenTokenRefreshController {
                 authUtil.extendSession();
             }
             return pg.setRedirect(true);
+        } catch (CalloutException e) {
+            LoggerUtility logger = new LoggerUtility(
+                CRM_ApplicationDomain.Domain.PLATFORCE,
+                'IdPorten'
+            );
+            if (e.getMessage().contains('Read timed out')) {
+                // No need for Critical or error on timeout
+                logger.logMessage(
+                    LoggerUtility.LogLevel.WARNING,
+                    '',
+                    '',
+                    e.getMessage(),
+                    e.getStackTraceString(),
+                    null
+                );
+            } else {
+                logger.exception(e);
+            }
+            logger.publishSynch();
         } catch (Exception e) {
-            LoggerUtility logger = new LoggerUtility();
-            logger.exception(e, CRM_ApplicationDomain.Domain.CRM);
+            LoggerUtility logger = new LoggerUtility(
+                CRM_ApplicationDomain.Domain.PLATFORCE,
+                'IdPorten'
+            );
+            logger.exception(e);
             logger.publishSynch();
         }
         return null;

--- a/force-app/IdPorten/classes/IdPortenTokenRefreshController.cls
+++ b/force-app/IdPorten/classes/IdPortenTokenRefreshController.cls
@@ -107,6 +107,10 @@ public with sharing class IdPortenTokenRefreshController {
             redirectUrlCookie = ApexPages.currentPage()
                 .getCookies()
                 .get('redirectUrl');
+
+            if (redirectUrlCookie == null) {
+                throw new IdPortenException('Redirect URL cookie is not set.');
+            }
             String redirectUrlFromCookie = redirectUrlCookie.getValue();
             pageReference pg = new pageReference(redirectUrlFromCookie);
 
@@ -152,6 +156,28 @@ public with sharing class IdPortenTokenRefreshController {
                 authUtil.extendSession();
             }
             return pg.setRedirect(true);
+        } catch (IdPortenException e) {
+            LoggerUtility logger = new LoggerUtility(
+                CRM_ApplicationDomain.Domain.PLATFORCE,
+                'IdPorten'
+            );
+
+            if (
+                e.getMessage()
+                    .equalsIgnoreCase('Redirect URL cookie is not set.')
+            ) {
+                logger.logMessage(
+                    LoggerUtility.LogLevel.ERROR,
+                    '',
+                    '',
+                    e.getMessage(),
+                    e.getStackTraceString(),
+                    null
+                );
+            } else {
+                logger.exception(e);
+            }
+            logger.publishSynch();
         } catch (CalloutException e) {
             LoggerUtility logger = new LoggerUtility(
                 CRM_ApplicationDomain.Domain.PLATFORCE,

--- a/force-app/IdPorten/classes/IdPortenTokenRefreshController.cls
+++ b/force-app/IdPorten/classes/IdPortenTokenRefreshController.cls
@@ -1,16 +1,20 @@
 public with sharing class IdPortenTokenRefreshController {
     private static final Integer SESSION_DURATION_IN_MINUTES = 24;
+    LoggerUtility logger;
+
+    public IdPortenTokenRefreshController() {
+        logger = new LoggerUtility(
+            CRM_ApplicationDomain.Domain.PLATFORCE,
+            'IdPorten'
+        );
+    }
+
+    public Boolean isScratchOrg(String domainURL) {
+        return domainURL.endsWithIgnoreCase('.scratch.my.salesforce.com');
+    }
 
     public PageReference validateAndRedirect() {
-        // Code from https://salesforce.stackexchange.com/questions/256499/how-can-i-determine-if-the-org-that-im-currently-connected-to-is-a-scratch-org
-        Organization org = [
-            SELECT IsSandbox, TrialExpirationDate
-            FROM Organization
-        ];
-        Boolean isScratchOrg =
-            org?.IsSandbox && org?.TrialExpirationDate != null;
-
-        if (isScratchOrg == true) {
+        if (this.isScratchOrg(URL.getOrgDomainUrl().toExternalForm()) == true) {
             String redirectUrl = ApexPages.currentPage()
                 .getParameters()
                 .get('redirectUrl');
@@ -119,12 +123,7 @@ public with sharing class IdPortenTokenRefreshController {
                 stateCookie == null ||
                 nonceCookie == null
             ) {
-                LoggerUtility logger = new LoggerUtility();
-                logger.error(
-                    'Cookies er ikke satt',
-                    null,
-                    CRM_ApplicationDomain.Domain.NKS
-                );
+                logger.error('Cookies er ikke satt', null);
                 logger.publishSynch();
                 return pg.setRedirect(true);
             }
@@ -134,12 +133,7 @@ public with sharing class IdPortenTokenRefreshController {
             String nonceFromCookie = nonceCookie.getValue();
 
             if (state == null || state != stateFromCookie) {
-                LoggerUtility logger = new LoggerUtility();
-                logger.error(
-                    'State samsvarer ikke',
-                    null,
-                    CRM_ApplicationDomain.Domain.NKS
-                );
+                logger.error('State samsvarer ikke', null);
                 logger.publishSynch();
                 return pg.setRedirect(true);
             }
@@ -157,11 +151,6 @@ public with sharing class IdPortenTokenRefreshController {
             }
             return pg.setRedirect(true);
         } catch (IdPortenException e) {
-            LoggerUtility logger = new LoggerUtility(
-                CRM_ApplicationDomain.Domain.PLATFORCE,
-                'IdPorten'
-            );
-
             if (
                 e.getMessage()
                     .equalsIgnoreCase('Redirect URL cookie is not set.')
@@ -177,12 +166,7 @@ public with sharing class IdPortenTokenRefreshController {
             } else {
                 logger.exception(e);
             }
-            logger.publishSynch();
         } catch (CalloutException e) {
-            LoggerUtility logger = new LoggerUtility(
-                CRM_ApplicationDomain.Domain.PLATFORCE,
-                'IdPorten'
-            );
             if (e.getMessage().contains('Read timed out')) {
                 // No need for Critical or error on timeout
                 logger.logMessage(
@@ -196,13 +180,11 @@ public with sharing class IdPortenTokenRefreshController {
             } else {
                 logger.exception(e);
             }
-            logger.publishSynch();
         } catch (Exception e) {
-            LoggerUtility logger = new LoggerUtility(
-                CRM_ApplicationDomain.Domain.PLATFORCE,
-                'IdPorten'
-            );
             logger.exception(e);
+        }
+
+        if (logger.peek() != null) {
             logger.publishSynch();
         }
         return null;

--- a/force-app/IdPorten/classes/IdPortenTokenRefreshController.cls-meta.xml
+++ b/force-app/IdPorten/classes/IdPortenTokenRefreshController.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>59.0</apiVersion>
+    <apiVersion>64.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/IdPorten/classes/IdPortenTokenRefreshController_Test.cls
+++ b/force-app/IdPorten/classes/IdPortenTokenRefreshController_Test.cls
@@ -284,6 +284,80 @@ private class IdPortenTokenRefreshController_Test {
         );
     }
 
+    @IsTest
+    private static void redirect_handleCallback_redirectCookieEmpty() {
+        System.Test.setMock(
+            HttpCalloutMock.class,
+            new CalloutExceptionRequestMock('Read timed out')
+        );
+
+        Cookie codeVerifierCookie = new Cookie(
+            'codeverifier',
+            'codeverifier',
+            null,
+            -1,
+            true
+        );
+        Cookie stateCookie = new Cookie('state', 'state', null, -1, true);
+        Cookie nonceCookie = new Cookie('nonce', 'noncetest', null, -1, true);
+        Pagereference pageRef = Page.IdPortenTokenRefresh;
+        pageRef.setCookies(
+            new List<Cookie>{ codeVerifierCookie, stateCookie, nonceCookie }
+        );
+
+        System.Test.setCurrentPage(pageRef);
+
+        pageRef.getParameters().put('code', 'abc');
+        pageRef.getParameters().put('state', 'state');
+
+        System.Test.startTest();
+        new IdPortenTokenRefreshController().redirect();
+        System.Test.stopTest();
+
+        List<Application_Log__c> logs = [
+            SELECT
+                Log_Message__c,
+                Log_Level__c,
+                Pay_Load__c,
+                Source_Class__c,
+                Application_Domain__c,
+                Category__c
+            FROM Application_Log__c
+            WHERE Source_Class__c = 'IdPortenTokenRefreshController'
+        ];
+
+        System.Assert.areEqual(
+            1,
+            logs.size(),
+            'Expected one log entry for missing redirect URL cookie'
+        );
+        System.Assert.areEqual(
+            'Redirect URL cookie is not set.',
+            logs[0].Log_Message__c,
+            'Expected log message for missing redirect URL cookie'
+        );
+        System.Assert.areEqual(
+            'Error',
+            logs[0].Log_Level__c,
+            'Expected log level to be Error'
+        );
+        System.Assert.areEqual(
+            'IdPortenTokenRefreshController',
+            logs[0].Source_Class__c,
+            'Expected source class to be IdPortenTokenRefreshController'
+        );
+        System.Assert.areEqual(
+            'PLATFORCE',
+            logs[0].Application_Domain__c,
+            'Expected application domain to be PLATFORCE'
+        );
+        System.Assert.areEqual(
+            'IdPorten',
+            logs[0].Category__c,
+            'Expected category to be IdPorten'
+        );
+    }
+
     public class TokenEndpointMock implements HttpCalloutMock {
         public HTTPResponse respond(HTTPRequest request) {
             HttpResponse res = new HttpResponse();

--- a/force-app/IdPorten/classes/IdPortenTokenRefreshController_Test.cls
+++ b/force-app/IdPorten/classes/IdPortenTokenRefreshController_Test.cls
@@ -24,12 +24,31 @@ private class IdPortenTokenRefreshController_Test {
         Test.setMock(HttpCalloutMock.class, new TokenEndpointMock());
 
         //set cookies
-        Cookie codeVerifierCookie = new Cookie('codeverifier', 'codeverifier', null, -1, true);
+        Cookie codeVerifierCookie = new Cookie(
+            'codeverifier',
+            'codeverifier',
+            null,
+            -1,
+            true
+        );
         Cookie stateCookie = new Cookie('state', 'state', null, -1, true);
         Cookie nonceCookie = new Cookie('nonce', 'noncetest', null, -1, true);
-        Cookie redirectUrlCookie = new Cookie('redirectUrl', '/', null, -1, true);
+        Cookie redirectUrlCookie = new Cookie(
+            'redirectUrl',
+            '/',
+            null,
+            -1,
+            true
+        );
         Pagereference pageRef = Page.IdPortenTokenRefresh;
-        pageRef.setCookies(new List<Cookie>{ codeVerifierCookie, stateCookie, nonceCookie, redirectUrlCookie });
+        pageRef.setCookies(
+            new List<Cookie>{
+                codeVerifierCookie,
+                stateCookie,
+                nonceCookie,
+                redirectUrlCookie
+            }
+        );
 
         Test.startTest();
 
@@ -41,14 +60,20 @@ private class IdPortenTokenRefreshController_Test {
         Test.stopTest();
 
         System.assertEquals('/', nextPage, 'Expected to finish login flow');
-        System.assertEquals(0, [SELECT COUNT() FROM Application_Log__c], 'Expect no errors');
+        System.assertEquals(
+            0,
+            [SELECT COUNT() FROM Application_Log__c],
+            'Expect no errors'
+        );
 
         System.assertEquals(
             1,
             [
                 SELECT COUNT()
                 FROM IdPortenCache__c
-                WHERE ExpirationTime__c > :DateTime.Now().addMinutes(20) AND UserId__c = :UserInfo.getUserId()
+                WHERE
+                    ExpirationTime__c > :DateTime.Now().addMinutes(20)
+                    AND UserId__c = :UserInfo.getUserId()
             ],
             'Expect Id Porten cache expiration time to be extended'
         );
@@ -58,7 +83,13 @@ private class IdPortenTokenRefreshController_Test {
     private static void redirect_handleCallback_whenCookiesIsNotSet() {
         Test.setMock(HttpCalloutMock.class, new TokenEndpointMock());
 
-        Cookie redirectUrlCookie = new Cookie('redirectUrl', '/', null, -1, true);
+        Cookie redirectUrlCookie = new Cookie(
+            'redirectUrl',
+            '/',
+            null,
+            -1,
+            true
+        );
         Pagereference pageRef = Page.IdPortenTokenRefresh;
         pageRef.setCookies(new List<Cookie>{ redirectUrlCookie });
 
@@ -78,7 +109,10 @@ private class IdPortenTokenRefreshController_Test {
             ORDER BY CreatedDate
         ];
         System.assertEquals(1, errorLogs.size(), 'Throw 1 error');
-        System.assertEquals('Cookies er ikke satt', errorLogs[0].Log_Message__c);
+        System.assertEquals(
+            'Cookies er ikke satt',
+            errorLogs[0].Log_Message__c
+        );
     }
 
     @IsTest
@@ -86,12 +120,31 @@ private class IdPortenTokenRefreshController_Test {
         Test.setMock(HttpCalloutMock.class, new TokenEndpointMock());
 
         //set cookies
-        Cookie codeVerifierCookie = new Cookie('codeverifier', 'codeverifier', null, -1, true);
+        Cookie codeVerifierCookie = new Cookie(
+            'codeverifier',
+            'codeverifier',
+            null,
+            -1,
+            true
+        );
         Cookie stateCookie = new Cookie('state', 'state', null, -1, true);
         Cookie nonceCookie = new Cookie('nonce', 'noncetest', null, -1, true);
-        Cookie redirectUrlCookie = new Cookie('redirectUrl', '/', null, -1, true);
+        Cookie redirectUrlCookie = new Cookie(
+            'redirectUrl',
+            '/',
+            null,
+            -1,
+            true
+        );
         Pagereference pageRef = Page.IdPortenTokenRefresh;
-        pageRef.setCookies(new List<Cookie>{ codeVerifierCookie, stateCookie, nonceCookie, redirectUrlCookie });
+        pageRef.setCookies(
+            new List<Cookie>{
+                codeVerifierCookie,
+                stateCookie,
+                nonceCookie,
+                redirectUrlCookie
+            }
+        );
 
         Test.startTest();
 
@@ -109,7 +162,10 @@ private class IdPortenTokenRefreshController_Test {
             WHERE Source_Class__c = 'IdPortenTokenRefreshController'
         ];
         System.assertEquals(1, errorLogs.size(), 'Throw 1 error');
-        System.assertEquals('State samsvarer ikke', errorLogs[0].Log_Message__c);
+        System.assertEquals(
+            'State samsvarer ikke',
+            errorLogs[0].Log_Message__c
+        );
     }
 
     @IsTest
@@ -125,14 +181,107 @@ private class IdPortenTokenRefreshController_Test {
         PageReference redirectPage = controller.validateAndRedirect();
         Test.stopTest();
         String nextPage = redirectPage.getUrl();
-        
-        Organization org = [SELECT IsSandbox, TrialExpirationDate FROM Organization];
-        Boolean isScratchOrg = org?.IsSandbox && org?.TrialExpirationDate != null;
-        if(isScratchOrg) {
+
+        Organization org = [
+            SELECT IsSandbox, TrialExpirationDate
+            FROM Organization
+        ];
+        Boolean isScratchOrg =
+            org?.IsSandbox && org?.TrialExpirationDate != null;
+        if (isScratchOrg) {
             Assert.areEqual('/', nextPage, 'Expected to get redirectUrl');
         } else {
-            Assert.isTrue(nextPage.startsWith('https://auth'), 'Expected to get auth URL outside scratch');
+            Assert.isTrue(
+                nextPage.startsWith('https://auth'),
+                'Expected to get auth URL outside scratch'
+            );
         }
+    }
+
+    @IsTest
+    private static void redirect_handleCallback_calloutTimeout() {
+        System.Test.setMock(
+            HttpCalloutMock.class,
+            new CalloutExceptionRequestMock('Read timed out')
+        );
+
+        Cookie codeVerifierCookie = new Cookie(
+            'codeverifier',
+            'codeverifier',
+            null,
+            -1,
+            true
+        );
+        Cookie stateCookie = new Cookie('state', 'state', null, -1, true);
+        Cookie nonceCookie = new Cookie('nonce', 'noncetest', null, -1, true);
+        Cookie redirectUrlCookie = new Cookie(
+            'redirectUrl',
+            '/',
+            null,
+            -1,
+            true
+        );
+        Pagereference pageRef = Page.IdPortenTokenRefresh;
+        pageRef.setCookies(
+            new List<Cookie>{
+                codeVerifierCookie,
+                stateCookie,
+                nonceCookie,
+                redirectUrlCookie
+            }
+        );
+
+        System.Test.setCurrentPage(pageRef);
+
+        pageRef.getParameters().put('code', 'abc');
+        pageRef.getParameters().put('state', 'state');
+
+        System.Test.startTest();
+        new IdPortenTokenRefreshController().redirect();
+        System.Test.stopTest();
+
+        List<Application_Log__c> logs = [
+            SELECT
+                Log_Message__c,
+                Log_Level__c,
+                Pay_Load__c,
+                Source_Class__c,
+                Application_Domain__c,
+                Category__c
+            FROM Application_Log__c
+            WHERE Source_Class__c = 'IdPortenTokenRefreshController'
+        ];
+
+        System.Assert.areEqual(
+            1,
+            logs.size(),
+            'Expected one log entry for callout timeout'
+        );
+        System.Assert.areEqual(
+            'Read timed out',
+            logs[0].Log_Message__c,
+            'Expected log message for callout timeout'
+        );
+        System.Assert.areEqual(
+            'Warning',
+            logs[0].Log_Level__c,
+            'Expected log level to be Warning'
+        );
+        System.Assert.areEqual(
+            'IdPortenTokenRefreshController',
+            logs[0].Source_Class__c,
+            'Expected source class to be IdPortenTokenRefreshController'
+        );
+        System.Assert.areEqual(
+            'PLATFORCE',
+            logs[0].Application_Domain__c,
+            'Expected application domain to be PLATFORCE'
+        );
+        System.Assert.areEqual(
+            'IdPorten',
+            logs[0].Category__c,
+            'Expected category to be IdPorten'
+        );
     }
 
     public class TokenEndpointMock implements HttpCalloutMock {
@@ -140,7 +289,11 @@ private class IdPortenTokenRefreshController_Test {
             HttpResponse res = new HttpResponse();
             res.setHeader('Content-Type', 'application/xml');
             String idToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdF9oYXNoIjoiSGs1TDE4WVVDTVZHbjFLNFBpckY2QSIsInN1YiI6Ii10c01LdWxFNUZHQUU1WkhRRUVlLWNsT2ZqS1VheGpYVmNXc2RsaHFBRWM9IiwiYW1yIjpbIkJhbmtJRCJdLCJpc3MiOiJodHRwczovL29pZGMtdmVyMi5kaWZpLm5vL2lkcG9ydGVuLW9pZGMtcHJvdmlkZXIvIiwicGlkIjoiMTYxMjAxMDExODEiLCJsb2NhbGUiOiJuYiIsInNpZCI6IlFzU29kZkNEVXBLUklZUWJfZkwyS1VkLTdVVUJ4RW5RejdtY0p4TVgzNDQiLCJhdWQiOiJhMDY5NjYxMi1lZmM0LTQ2ZTktYTdjOS1iZmY2NTZlNTU0YzIiLCJhY3IiOiJMZXZlbDQiLCJhdXRoX3RpbWUiOjE2NDYyMjU4MjIsImV4cCI6MTY0NjIyNzE2MywiaWF0IjoxNjQ2MjI3MDQzLCJub25jZSI6Im5vbmNldGVzdCIsImp0aSI6Ik41Uk1KQmZhYnlOTklkZUFpcmMxZUJmMUZYX1VQNHhjazVZUEoydWhQQncifQ.5-MEpzms1cH97aAFVM2bNATADrdSiWxt1s_ZtiOgJ1w';
-            res.setBody('{"access_token":"access","refresh_token":"refresh", "id_token":"' + idToken + '"}');
+            res.setBody(
+                '{"access_token":"access","refresh_token":"refresh", "id_token":"' +
+                    idToken +
+                    '"}'
+            );
             res.setStatusCode(200);
             return res;
         }

--- a/force-app/IdPorten/classes/IdPortenTokenRefreshController_Test.cls
+++ b/force-app/IdPorten/classes/IdPortenTokenRefreshController_Test.cls
@@ -10,6 +10,24 @@ private class IdPortenTokenRefreshController_Test {
     }
 
     @IsTest
+    private static void test_isScratchOrg() {
+        IdPortenTokenRefreshController controller = new IdPortenTokenRefreshController();
+        String scratchDomainURL = 'https://test.scratch.my.salesforce.com';
+        String sandboxDomainURL = 'https://test.sandbox.my.salesforce.com';
+        String prodDomainURL = 'https://test.my.salesforce.com';
+
+        Test.startTest();
+        Boolean scratchResult = controller.isScratchOrg(scratchDomainURL);
+        Boolean sandboxResult = controller.isScratchOrg(sandboxDomainURL);
+        Boolean prodResult = controller.isScratchOrg(prodDomainURL);
+        Test.stopTest();
+
+        System.Assert.isTrue(scratchResult, 'Expected to be a scratch org');
+        System.Assert.isFalse(sandboxResult, 'Expected to be a sandbox org');
+        System.Assert.isFalse(prodResult, 'Expected to be a prod org');
+    }
+
+    @IsTest
     private static void redirect_getAuthorizationCodeUrl() {
         Test.startTest();
         IdPortenTokenRefreshController controller = new IdPortenTokenRefreshController();

--- a/force-app/IdPorten/classes/IdPortenTokenRefreshController_Test.cls-meta.xml
+++ b/force-app/IdPorten/classes/IdPortenTokenRefreshController_Test.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>59.0</apiVersion>
+    <apiVersion>64.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/IdPorten/permissionsets/IdPortenLogoutRest_Service.permissionset-meta.xml
+++ b/force-app/IdPorten/permissionsets/IdPortenLogoutRest_Service.permissionset-meta.xml
@@ -18,62 +18,7 @@
         <allowRead>true</allowRead>
         <modifyAllRecords>true</modifyAllRecords>
         <object>IdPortenCache__c</object>
+        <viewAllFields>false</viewAllFields>
         <viewAllRecords>true</viewAllRecords>
     </objectPermissions>
-    <userPermissions>
-        <enabled>true</enabled>
-        <name>AssignPermissionSets</name>
-    </userPermissions>
-    <userPermissions>
-        <enabled>true</enabled>
-        <name>DelegatedTwoFactor</name>
-    </userPermissions>
-    <userPermissions>
-        <enabled>true</enabled>
-        <name>ManageInternalUsers</name>
-    </userPermissions>
-    <userPermissions>
-        <enabled>true</enabled>
-        <name>ManageIpAddresses</name>
-    </userPermissions>
-    <userPermissions>
-        <enabled>true</enabled>
-        <name>ManageLoginAccessPolicies</name>
-    </userPermissions>
-    <userPermissions>
-        <enabled>true</enabled>
-        <name>ManagePasswordPolicies</name>
-    </userPermissions>
-    <userPermissions>
-        <enabled>true</enabled>
-        <name>ManageProfilesPermissionsets</name>
-    </userPermissions>
-    <userPermissions>
-        <enabled>true</enabled>
-        <name>ManageRoles</name>
-    </userPermissions>
-    <userPermissions>
-        <enabled>true</enabled>
-        <name>ManageSharing</name>
-    </userPermissions>
-    <userPermissions>
-        <enabled>true</enabled>
-        <name>ManageUsers</name>
-    </userPermissions>
-    <userPermissions>
-        <enabled>true</enabled>
-        <name>ResetPasswords</name>
-    </userPermissions>
-    <userPermissions>
-        <enabled>true</enabled>
-        <name>ViewAllUsers</name>
-    </userPermissions>
-    <userPermissions>
-        <enabled>true</enabled>
-        <name>ViewRoles</name>
-    </userPermissions>
-    <userPermissions>
-        <enabled>true</enabled>
-        <name>ViewSetup</name>
-    </userPermissions>
 </PermissionSet>

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -8,7 +8,7 @@
             "dependencies": [
                 {
                     "package": "crm-platform-base",
-                    "versionNumber": "0.270.0.LATEST"
+                    "versionNumber": "0.271.0.LATEST"
                 },
                 {
                     "package": "crm-platform-access-control",
@@ -19,7 +19,7 @@
     ],
     "namespace": "",
     "sfdcLoginUrl": "https://login.salesforce.com",
-    "sourceApiVersion": "58.0",
+    "sourceApiVersion": "64.0",
     "packageAliases": {
         "crm-platform-base": "0Ho2o0000008ORmCAM",
         "crm-platform-access-control": "0Ho2o0000008OR3CAM",


### PR DESCRIPTION
**Hensikt:**
Denne PR-en refaktorerer IdPortenTokenRefreshController for å forbedre logging, feilhåndtering og lesbarhet i koden. Det er også lagt til en egen custom exception og utvidet testdekning for nye og eksisterende scenarioer.

**Viktige endringer:**

- Lagt til en ny custom exception-klasse IdPortenException for å håndtere spesifikke IdPorten-feil.
- Refaktorert IdPortenTokenRefreshController:
  - Sentralisert logging via en dedikert LoggerUtility-instans.
  - Forbedret feilhåndtering for manglende cookies, state mismatch, callout timeouts og ukjente unntak, med mer presise loggmeldinger og riktig loggnivå.
  - Lagt til spesifikk håndtering og logging for “Redirect URL cookie is not set” og callout timeout.
  - Lagt til hjelpefunksjonen isScratchOrg() for bedre å kunne avgjøre org-type og forenkle koden.
- Utvidet testdekning:
  - Lagt til nye tester for ulike feilsituasjoner (callout timeout, manglende redirect URL-cookie osv.).
  - Refaktorert og utvidet eksisterende tester for å dekke ny logikk og styrke assertions.
- Oppdatert metadata-XML-filer og bumpet apiVersion til 64.0 der det er relevant.
- Oppdatert sfdx-project.json til å bruke siste versjon av pakker og sourceApiVersion.