### PR TITLE
TOLK-3562 : Feil med dato og tid på bestillingsskjema med voiceover på mobil

### DIFF
--- a/force-app/main/default/lwc/input/input.html
+++ b/force-app/main/default/lwc/input/input.html
@@ -28,6 +28,8 @@
             value={value}
             maxlength={maxLength}
             minlength={minLength}
+            role={accessibilityRole}
+            aria-label={label}
         />
         <div if:true={showError} id="errorTextId" aria-relevant="additions removals" aria-live="polite" role="alert">
             <div class="navds-error-message navds-error-message--medium navds-label" style={errorFontSize}>

--- a/force-app/main/default/lwc/input/input.js
+++ b/force-app/main/default/lwc/input/input.js
@@ -49,6 +49,12 @@ export default class Input extends LightningElement {
         return convertStringToBoolean(this.autofocus);
     }
 
+    get accessibilityRole() {
+        return this.type === 'date' || this.type === 'time'
+            ? 'textbox'
+            : null;
+    }
+
     // Call this when value is needed
     @api getValue() {
         return this.template.querySelector('input').value;


### PR DESCRIPTION
Innmeldt problem: Har en db bruker som sliter med å bestille tolk via appen. Hen skriver: Når jeg bruker voiceover på mobilen blir dato og starttid lest opp, men får ikke trykke eller aktivere for å skrive eller velge dato og kl slett. 